### PR TITLE
Fix; check for instances of None

### DIFF
--- a/ausseabed/ggoutlier/qax/plugin.py
+++ b/ausseabed/ggoutlier/qax/plugin.py
@@ -104,7 +104,7 @@ class GgoutlierQaxPlugin(QaxCheckToolPlugin):
                 # ggoutlier include some util classes we can use to get details
                 # from the raster file
                 band_names = cloud2tif.getbandnames(f.path)
-                band_names = list(map(lambda x: x.lower(), band_names))
+                band_names = [name.lower() for name in band_names if name is not None]
 
                 # if there's a single band tif, and it has depth in the filename
                 # then use it


### PR DESCRIPTION
Minor fix to avoid failure if a given image file has no internally defined band names.

Resolves #2 

I will leave the ticket open till after we have a broader discussion.

It does raise the question on reporting a clearer error back on why the check was not run:

https://github.com/ausseabed/ggoutlier-qax-plugin/blob/main/ausseabed/ggoutlier/qax/plugin.py#L133-L142

A user may not realise that the absence of band names triggers the abort.